### PR TITLE
Bug fix for auto logout

### DIFF
--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -19,9 +19,12 @@ const App = () => {
 		*/
 
 		if (!IsAuthenticated()) {
+			console.log("Not Authenticated");
 			Logout();
+		} else {
+			console.log("Authenticated");
 		}
-	}, 15000);
+	}, 5000);
 
 	return (
 		<HashRouter>

--- a/ui/src/containers/auth/login.js
+++ b/ui/src/containers/auth/login.js
@@ -8,7 +8,6 @@ const LoginContainer = () => {
 	const [password, setPassword] = useState("");
 	const [error, setError] = useState(null);
 	const [loading, setLoading] = useState(false);
-	const [data, setData] = useState(null);
 
 	const isValid = () => {
 		if (username === "") {

--- a/ui/src/utils/user.js
+++ b/ui/src/utils/user.js
@@ -1,30 +1,38 @@
-const AccessTokenCookieName = "twms_ac";
+const AccessTokenKey = "twms_ac";
+const ExpiryKey = "twms_te";
 
-const GetAccessToken = () => {
-	const value = document.cookie.match(
-		"(^|;) ?" + AccessTokenCookieName + "=([^;]*)(;|$)"
-	);
-
-	return value ? value[2] : null;
-};
+const GetAccessToken = () => localStorage.getItem(AccessTokenKey);
 
 const Login = (token, expires) => {
 	expires *= 1000;
-	let d = new Date(expires);
-	d = d + d.getTimezoneOffset() * 60000;
+	const expiryDate = new Date(new Date(expires).toUTCString()).getTime();
 
-	document.cookie =
-		AccessTokenCookieName + "=" + token + ";path=/;expires=" + d;
+	localStorage.setItem(AccessTokenKey, token);
+	localStorage.setItem(ExpiryKey, expiryDate);
 
 	triggerListeners();
 };
 
 const Logout = () => {
-	Login(null, -1);
+	localStorage.removeItem(AccessTokenKey);
+	localStorage.removeItem(ExpiryKey);
+
+	triggerListeners();
 };
 
 const IsAuthenticated = () => {
-	return GetAccessToken() !== null;
+	const token = GetAccessToken();
+	if (!token) {
+		return false;
+	}
+
+	const time = localStorage.getItem(ExpiryKey);
+	const expiryDate = new Date(parseInt(time));
+	if (expiryDate < new Date()) {
+		return false;
+	}
+
+	return true;
 };
 
 const listeners = new Map();


### PR DESCRIPTION
Automatic logout failed due to client browsers not deleting cookies once they expired - assuming they did, the user utility didn't check if a cookie had expired or not. Access token data and expiry date are now stored in localStorage and the expiry date is now validated in IsAuthenticated.